### PR TITLE
Log error if .htmlhintrc file is broken

### DIFF
--- a/src/server/langServer/services/ismlLinting.ts
+++ b/src/server/langServer/services/ismlLinting.ts
@@ -559,7 +559,10 @@ function loadConfigurationFile(configFile: string): any {
 		try {
 			ruleSet = JSON.parse(stripJsonComments(config));
 		}
-		catch (e) { }
+		catch (e) {
+			console.warn('The .htmlhintrc configuration file is invalid. Source: ' + configFile);
+			console.warn(e);
+		}
 	}
 	return ruleSet;
 }


### PR DESCRIPTION
Add descriptive errors for invalid .htmlhintrc file:

```shell
htmlhint enabled
Finding files with custom tags... 
>>>> SyntaxError: Unexpected token } in JSON at position 38
    at JSON.parse (<anonymous>)
    at v (/Users/username/.vscode/extensions/sqrtt.prophet-1.3.1/dist/ismlServer.js:13:629276)
    at /Users/username/.vscode/extensions/sqrtt.prophet-1.3.1/dist/ismlServer.js:13:630107
    at /Users/username/.vscode/extensions/sqrtt.prophet-1.3.1/dist/ismlServer.js:13:630193
    at /Users/username/.vscode/extensions/sqrtt.prophet-1.3.1/dist/ismlServer.js:13:630218
    at Object.w [as validateTextDocument] (/Users/username/.vscode/extensions/sqrtt.prophet-1.3.1/dist/ismlServer.js:13:630653)
    at /Users/username/.vscode/extensions/sqrtt.prophet-1.3.1/dist/ismlServer.js:13:192807
    at invoke (/Users/username/.vscode/extensions/sqrtt.prophet-1.3.1/dist/ismlServer.js:1:42394)
    at r.fire (/Users/username/.vscode/extensions/sqrtt.prophet-1.3.1/dist/ismlServer.js:1:43219)
    at /Users/username/.vscode/extensions/sqrtt.prophet-1.3.1/dist/ismlServer.js:1:95487
```